### PR TITLE
Feat/add configuration

### DIFF
--- a/Domain/Entities/ActorEntity.cs
+++ b/Domain/Entities/ActorEntity.cs
@@ -7,10 +7,8 @@ namespace Domain.Entities
 {
     public class ActorEntity: Entity
     {
-        public string? FirstName { get; set; }
-
-        public string? LastName { get; set; }
-
-        public ICollection<MovieActorEntity> ActorsInMovies { get; set; }    
+        public string FirstName { get; set; } = null!;
+        public string LastName  { get; set; } = null!;
+        public ICollection<MovieActorEntity> ActorsInMovies { get; set; } = new List<MovieActorEntity>();
     }
 }

--- a/Domain/Entities/Enums/CategoryEnum.cs
+++ b/Domain/Entities/Enums/CategoryEnum.cs
@@ -6,8 +6,8 @@ namespace Domain.Entities.Enums
 {
     public enum CategoryEnum
     {
-      Film,
-      Cartoon,
-      Anime
+      Film = 1,
+      Cartoon = 2,
+      Anime = 3
     }
 }

--- a/Domain/Entities/Enums/GenreEnum.cs
+++ b/Domain/Entities/Enums/GenreEnum.cs
@@ -7,16 +7,16 @@ namespace Domain.Entities.Enums
 {
     public enum GenreEnum
     {
-       Action,
-       Adventure,
-       Comedy,
-       Drama,
-       Horror,
-       Thriller,
-       Crime,
-       Romance,
-       Science_Fiction,
-       Fantasy,
-       Mystery
+        Action = 1,
+        Adventure = 2,
+        Comedy = 3,
+        Drama = 4,
+        Horror = 5,
+        Thriller = 6,
+        Crime = 7,
+        Romance = 8,
+        Science_Fiction = 9,
+        Fantasy = 10,
+        Mystery = 11
     }
 }

--- a/Domain/Entities/Enums/SeatStatusEnum.cs
+++ b/Domain/Entities/Enums/SeatStatusEnum.cs
@@ -6,7 +6,7 @@ namespace Domain.Entities.Enums
 {
     public enum SeatStatusEnum
     {
-        Booked,
-        Active
+        Booked = 1 ,
+        Active = 2
     }
 }

--- a/Domain/Entities/Enums/SeatTypeEnum.cs
+++ b/Domain/Entities/Enums/SeatTypeEnum.cs
@@ -6,7 +6,7 @@ namespace Domain.Entities.Enums
 {
     public enum SeatTypeEnum
     {
-        Standart,
-        VIP
+        Standart = 1,
+        VIP = 2
     }
 }

--- a/Domain/Entities/Enums/SessionStatusEnum.cs
+++ b/Domain/Entities/Enums/SessionStatusEnum.cs
@@ -4,10 +4,10 @@ using System.Text;
 
 namespace Domain.Entities.Enums
 {
-    public enum StatusEnum
+    public enum SessionStatusEnum
     {
-        Cancelled,
-        Finished,
-        Scheduled
+        Cancelled = 1,
+        Finished = 2,
+        Scheduled = 3
     }
 }

--- a/Domain/Entities/HallEntity.cs
+++ b/Domain/Entities/HallEntity.cs
@@ -7,16 +7,17 @@ namespace Domain.Entities
 {
     public class HallEntity:Entity
     {
-        public string? Name { get; set; }
+        public string Name { get; set; } = null!;
 
         public int Raws { get; set; }
 
         public int SeatsPerRaw { get; set; }
 
         public bool IsActive { get; set; }
+        
+        public ICollection<SessionEntity> Sessions { get; set; } = new List<SessionEntity>();
+        
+        public ICollection<SeatEntity> Seats { get; set; } = new List<SeatEntity>();
 
-        public ICollection<SessionEntity> Sessions { get; set; }
-
-        public ICollection<SeatEntity> Seats { get; set; }
     }
 }

--- a/Domain/Entities/MovieEntity.cs
+++ b/Domain/Entities/MovieEntity.cs
@@ -10,29 +10,27 @@ namespace Domain.Entities
     public class MovieEntity:Entity
     {
         public string? Poster { get; set; }
+        public string Title { get; set; } = null!;
+        public string Description { get; set; } = null!;
 
-        public string? Description { get; set; }
-
-        public CategoryEnum Category { get; set; }
+        public CategoryEnum Category { get; set; } 
 
         public GenreEnum Genre { get; set; }
 
         public int Duration { get; set; }
 
-        public decimal Rating { get; set; }
+        public decimal? Rating { get; set; }
 
-        public DateTime? StartedAt { get; set; }
-
-        public DateTime? EndedAt {  get; set; }
+        public DateTime RentalStartDate { get; set; }
+        
+        public DateTime RentalEndDate { get; set; }
 
         public bool IsActive { get; set; }
 
-        public DateTime CreatedAt { get; set; }
-
-        public ICollection<MovieActorEntity> ActorsInMovies { get; set; }
-
-        public ICollection<ViewHistoryEntity> MoviesViewed { get; set; }
-
-        public ICollection<SessionEntity> Sessions { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        
+        public ICollection<MovieActorEntity> ActorsInMovies { get; set; } = new List<MovieActorEntity>();
+        public ICollection<ViewHistoryEntity> MoviesViewed { get; set; } = new List<ViewHistoryEntity>();
+        public ICollection<SessionEntity> Sessions { get; set; } = new List<SessionEntity>();
     }
 }

--- a/Domain/Entities/SessionEntity.cs
+++ b/Domain/Entities/SessionEntity.cs
@@ -21,7 +21,7 @@ namespace Domain.Entities
 
         public DateTime? EndTime { get; set;}
 
-        public StatusEnum Status { get; set; }
+        public SessionStatusEnum SessionStatus { get; set; }
 
         public ICollection<TicketEntity> Tickets { get; set; }
     }

--- a/Infrastructure/EntitiesConfiguration/ActorConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/ActorConfiguration.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Domain.Entities;
+
+namespace Infrastructure.EntitiesConfiguration
+{
+    public class ActorConfiguration : IEntityTypeConfiguration<ActorEntity>
+    {
+        public void Configure(EntityTypeBuilder<ActorEntity> builder)
+        {
+            builder.ToTable("actor");
+            
+            builder.HasKey(a => a.Id);
+            builder.Property(a => a.Id)
+                .HasColumnName("actor_id");
+            
+            builder.Property(a => a.FirstName)
+                .HasColumnName("first_name").HasMaxLength(30)
+                .IsRequired();
+            
+            builder.Property(a => a.LastName)
+                .HasColumnName("last_name")
+                .HasMaxLength(40).IsRequired();;
+        }
+    }
+}

--- a/Infrastructure/EntitiesConfiguration/HallConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/HallConfiguration.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Domain.Entities;
+
+namespace Infrastructure.EntitiesConfiguration
+{
+    public class HallConfiguration : IEntityTypeConfiguration<HallEntity>
+    {
+        public void Configure(EntityTypeBuilder<HallEntity> builder)
+        {
+            builder.ToTable("hall");
+
+            builder.HasKey(h => h.Id);
+            builder.Property(h => h.Id)
+                .HasColumnName("hall_id");
+
+            
+            builder.Property(h => h.Name)
+                .HasColumnName("name")
+                .IsRequired();
+            builder.HasIndex(h => h.Name)
+                .IsUnique();
+
+            
+            builder.Property(h => h.Raws)
+                .HasColumnName("rows_count")
+                .IsRequired();
+
+            
+            builder.Property(h => h.SeatsPerRaw)
+                .HasColumnName("seats_per_row")
+                .IsRequired();
+
+            
+            builder.Property(h => h.IsActive)
+                .HasColumnName("is_active")
+                .IsRequired();
+        }
+    }
+}

--- a/Infrastructure/EntitiesConfiguration/MovieActorConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/MovieActorConfiguration.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Domain.Entities;
+
+
+namespace Infrastructure.EntitiesConfiguration
+{
+    public class MovieActorConfiguration : IEntityTypeConfiguration<MovieActorEntity>
+    {
+        public void Configure(EntityTypeBuilder<MovieActorEntity> builder)
+        {
+            builder.ToTable("movie_actors");
+            
+            builder.HasKey(h => h.Id);
+            builder.Property(h => h.Id)
+                .HasColumnName("movie_actors_id");
+            
+            
+            builder.Property(ma => ma.ActorId)
+                .HasColumnName("actor_id")
+                .IsRequired();
+
+            
+            builder.HasIndex(ma => new { ma.MovieId, ma.ActorId })
+                .IsUnique();
+
+
+            builder.HasOne(ma => ma.Movie)
+                .WithMany(m => m.ActorsInMovies)
+                .HasForeignKey(ma => ma.MovieId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+
+            builder.HasOne(ma => ma.Actor)
+                .WithMany(a => a.ActorsInMovies)
+                .HasForeignKey(ma => ma.ActorId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/Infrastructure/EntitiesConfiguration/MovieActorConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/MovieActorConfiguration.cs
@@ -16,6 +16,11 @@ namespace Infrastructure.EntitiesConfiguration
                 .HasColumnName("movie_actors_id");
             
             
+            builder.Property(ma => ma.MovieId)
+                .HasColumnName("movie_id")
+                .IsRequired();
+            
+            
             builder.Property(ma => ma.ActorId)
                 .HasColumnName("actor_id")
                 .IsRequired();

--- a/Infrastructure/EntitiesConfiguration/MovieConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/MovieConfiguration.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Domain.Entities;
+
+namespace Infrastructure.EntitiesConfiguration
+{
+    public class MovieConfiguration : IEntityTypeConfiguration<MovieEntity>
+    {
+        public void Configure(EntityTypeBuilder<MovieEntity> builder)
+        {
+            builder.ToTable("movie");
+            
+            builder.HasKey(m => m.Id);
+            builder.Property(m => m.Id)
+                .HasColumnName("movie_id");
+            
+            
+            builder.Property(m => m.Poster)
+                .HasColumnName("poster");
+            
+            
+            builder.Property(m => m.Title)
+                .HasColumnName("title")
+                .IsRequired();
+            builder.HasIndex(m => m.Title)
+                .IsUnique();
+
+            
+            builder.Property(m => m.Description)
+                .HasColumnName("description")
+                .IsRequired();
+
+            
+            builder.Property(m => m.Category)
+                .HasColumnName("category_id")
+                .HasConversion<int>()
+                .IsRequired();
+
+            
+            builder.Property(m => m.Genre)
+                .HasColumnName("genre_id")
+                .HasConversion<int>()
+                .IsRequired();
+
+            
+            builder.Property(m => m.Duration)
+                .HasColumnName("duration_min")
+                .IsRequired();
+
+            
+            builder.Property(m => m.Rating)
+                .HasColumnName("rating")
+                .IsRequired(false);
+
+            
+            builder.Property(m => m.RentalStartDate)
+                .HasColumnName("start_of_rental")
+                .HasColumnType("date")
+                .IsRequired();
+
+            
+            builder.Property(m => m.RentalEndDate)
+                .HasColumnName("end_of_rental")
+                .HasColumnType("date")
+                .IsRequired();
+
+            
+            builder.Property(m => m.IsActive)
+                .HasColumnName("is_active")
+                .IsRequired();
+
+            
+            builder.Property(m => m.CreatedAt)
+                .HasColumnName("created_at")
+                .HasColumnType("timestamp")
+                .HasDefaultValueSql("timezone('utc', now())")
+                .IsRequired();
+        }
+    }
+}

--- a/Infrastructure/EntitiesConfiguration/MovieConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/MovieConfiguration.cs
@@ -22,8 +22,6 @@ namespace Infrastructure.EntitiesConfiguration
             builder.Property(m => m.Title)
                 .HasColumnName("title")
                 .IsRequired();
-            builder.HasIndex(m => m.Title)
-                .IsUnique();
 
             
             builder.Property(m => m.Description)

--- a/Infrastructure/EntitiesConfiguration/MovieConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/MovieConfiguration.cs
@@ -45,11 +45,10 @@ namespace Infrastructure.EntitiesConfiguration
                 .HasColumnName("duration_min")
                 .IsRequired();
 
-            
-            builder.Property(m => m.Rating)
-                .HasColumnName("rating")
-                .IsRequired(false);
 
+            builder.Property(m => m.Rating)
+                .HasColumnName("rating");
+            
             
             builder.Property(m => m.RentalStartDate)
                 .HasColumnName("start_of_rental")

--- a/Infrastructure/EntitiesConfiguration/SeatConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/SeatConfiguration.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Domain.Entities;
+
+
+namespace Infrastructure.EntitiesConfiguration
+{
+    public class SeatConfiguration : IEntityTypeConfiguration<SeatEntity>
+    {
+        public void Configure(EntityTypeBuilder<SeatEntity> builder)
+        {
+            builder.ToTable("seat");
+
+            builder.HasKey(s => s.Id);
+            builder.Property(s => s.Id)
+                .HasColumnName("seat_id");
+            
+            
+            builder.Property(s => s.HallId)
+                .HasColumnName("hall_id")
+                .IsRequired();
+
+            
+            builder.Property(s => s.RawNumber)
+                .HasColumnName("row_number")
+                .IsRequired();
+            
+                        
+            builder.Property(s => s.SeatNumber)
+                .HasColumnName("seat_number")
+                .IsRequired();
+
+            
+            builder.Property(s => s.SeatType)
+                .HasColumnName("seat_type")
+                .HasConversion<int>()
+                .IsRequired();
+            
+            
+            builder.Property(s => s.Status)
+                .HasColumnName("status")
+                .HasConversion<int>()
+                .IsRequired();
+            
+            
+            builder.HasIndex(s => new { s.HallId, s.RawNumber, s.SeatNumber })
+                .IsUnique();
+        }
+    }
+}

--- a/Infrastructure/EntitiesConfiguration/SessionConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/SessionConfiguration.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Domain.Entities;
+
+
+namespace Infrastructure.EntitiesConfiguration
+{
+    public class SessionConfiguration : IEntityTypeConfiguration<SessionEntity>
+    {
+        public void Configure(EntityTypeBuilder<SessionEntity> builder)
+        {
+            builder.ToTable("session");
+
+            builder.HasKey(s => s.Id);
+            builder.Property(s => s.Id)
+                .HasColumnName("session_id");
+            
+            
+            builder.Property(s => s.MovieId)
+                .HasColumnName("movie_id")
+                .IsRequired();
+            
+            
+            builder.Property(s => s.HallId)
+                .HasColumnName("hall_id")
+                .IsRequired();
+
+
+            builder.Property(s => s.StartTime)
+                .HasColumnName("start_time")
+                .HasColumnType("timestamp");
+
+
+            builder.Property(s => s.EndTime)
+                .HasColumnName("end_time")
+                .HasColumnType("timestamp");
+            
+            
+            builder.Property(s => s.SessionStatus)
+                .HasColumnName("status")
+                .HasConversion<int>()
+                .IsRequired();
+            
+            
+            builder.HasOne(s => s.Movie)
+                .WithMany(m => m.Sessions)
+                .HasForeignKey(s => s.MovieId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            
+            builder.HasOne(s => s.Hall)
+                .WithMany(h => h.Sessions)
+                .HasForeignKey(s => s.HallId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/Infrastructure/EntitiesConfiguration/TicketConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/TicketConfiguration.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Domain.Entities;
+
+
+namespace Infrastructure.EntitiesConfiguration
+{
+    public class TicketConfiguration : IEntityTypeConfiguration<TicketEntity>
+    {
+        public void Configure(EntityTypeBuilder<TicketEntity> builder)
+        {
+            builder.ToTable("ticket");
+
+            builder.HasKey(t => t.Id);
+            builder.Property(t => t.Id)
+                .HasColumnName("ticket_id");
+            
+            // builder.Property(t => t.UserId)
+            //     .HasColumnName("user_id")
+            //     .IsRequired();
+            
+            
+            builder.Property(t => t.SessionId)
+                .HasColumnName("session_id")
+                .IsRequired();
+            
+            
+            builder.Property(t => t.SeatId)
+                .HasColumnName("seat_id")
+                .IsRequired();
+            
+            builder.Property(t => t.CreatedAt)
+                .HasColumnName("created_at")
+                .HasColumnType("timestamp")
+                .IsRequired(false);
+            
+            
+            builder.Property(t => t.Price)
+                .HasColumnName("price")
+                .HasColumnType("numeric(10,2)")
+                .IsRequired();
+            
+            builder.HasIndex(t => new { t.SessionId, t.SeatId })
+                .IsUnique();
+            
+            
+            // builder.HasOne(t => t.User)
+            //     .WithMany(u => u.Tickets)
+            //     .HasForeignKey(t => t.UserId)
+            //     .OnDelete(DeleteBehavior.Cascade);
+            
+            
+            builder.HasOne(t => t.Session)
+                .WithMany(s => s.Tickets)
+                .HasForeignKey(t => t.SessionId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/Infrastructure/EntitiesConfiguration/ViewHistoryConfiguration.cs
+++ b/Infrastructure/EntitiesConfiguration/ViewHistoryConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Domain.Entities;
+
+
+namespace Infrastructure.EntitiesConfiguration
+{
+
+    public class ViewHistoryConfiguration : IEntityTypeConfiguration<ViewHistoryEntity>
+    {
+        public void Configure(EntityTypeBuilder<ViewHistoryEntity> builder)
+        {
+            builder.ToTable("history");
+            
+            builder.HasKey(h => h.Id);
+            builder.Property(h => h.Id)
+                .HasColumnName("history_id");
+            
+            
+            // builder.Property(h => h.UserId)
+            //     .HasColumnName("user_id")
+            //     .IsRequired();
+            
+            
+            builder.Property(h => h.MovieId)
+                .HasColumnName("movie_id")
+                .IsRequired();
+            
+            
+            builder.Property(h => h.ViewedAt)
+                .HasColumnName("viewed_at")
+                .HasColumnType("timestamp")
+                .IsRequired();
+            
+           
+            // builder.HasOne(h => h.User)
+            //     .WithMany(u => u.ViewHistory)
+            //     .HasForeignKey(h => h.UserId)
+            //     .OnDelete(DeleteBehavior.Cascade);
+            
+            
+            builder.HasOne(h => h.Movie)
+                .WithMany(m => m.MoviesViewed)
+                .HasForeignKey(h => h.MovieId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -11,9 +11,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.*" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Configurations\" />
     <Folder Include="Migrations\" />
     <Folder Include="Repositories\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Changes & notes

- Added entity configurations
- For all enums fixed explicit numeric values.  
  This is a best practice when enums are stored as `int` in the database, as it prevents data inconsistency if enum values are reordered or extended in the future

- I have a question regarding **User**:  
  User entity was not implemented at this stage so several related parts are currently commented out :(

- Regarding **enums (Category / Genre)**:  
  As implemented now a movie can have only one category and one genre.  
  The requirement is to support multiple categories or genres per movie, then a separate join table (many-to-many) would be required? What do you think?

- I did not add a strict **1:1 relationship between Seat and Ticket** because that would mean the same seat could never be used in more than one ticket even across different sessions.  
  Instead I enforced seat uniqueness within a hall using:
  ```csharp
  builder.HasIndex(s => new { s.HallId, s.RawNumber, s.SeatNumber })
      .IsUnique();
